### PR TITLE
Streamline Requests Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,17 @@ Julia package which simplifies the process of interacting with WMATA's public AP
 # Getting Started 
 You will need an API key from [WMATA's developer portal](https://developer.wmata.com/).
 
-You can get up and running with your subscription key using the `WMATA_auth()` function. This function verifies that you have a valid subscription key and sets a global variable called `WMATA_AuthToken` after verifying your key.
+You can get up and running with your subscription key using the `WMATA_auth()` function. This function verifies that you have a valid subscription key and sets a global struct called `wmata` that is accessible by the utility functions and rail methods.
 
 ```
 using WMATA
 WMATA_auth("your subscription key")
+#> Authentication complete.
 ```
 
 # Available Functions
 ## rail_predictions()
-Based on the *Real Time Rail Predictions* methods described in WMATA's documentation [here](https://developer.wmata.com/docs/services/547636a6f9182302184cda78/operations/547636a6f918230da855363f).
+Based on the *Real Time Rail Predictions* methods described in WMATA's documentation [here](https://developer.wmata.com/docs/services/547636a6f9182302184cda78/operations/547636a6f918230da855363f). You can provide a station code or station name.
 
 ```
 rail_predictions(StationCode = "All")
@@ -76,7 +77,7 @@ This will return the same DataFrame as above, with the following additions:
 
 ## station_timings()
 
-Returns a DataFrame of opening and scheduled first/last train times based on a given StationCode.
+Returns a DataFrame of opening and scheduled first/last train times based on a given StationCode or StationName.
 
 Note that for stations with multiple platforms (e.g.: Metro Center, L'Enfant Plaza, etc.), a distinct call is required for each StationCode to retrieve the full set of train times at such stations. 
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,0 +1,9 @@
+# struct containing api key and urls
+struct wmata_API 
+    api_key::String 
+    station_list_url::String
+    station_timings_url::String 
+    rail_predictions_url::String
+    paths_url::String 
+    station_to_station_url::String
+end

--- a/src/authentication.jl
+++ b/src/authentication.jl
@@ -5,7 +5,7 @@ an issue with their API. What I'd like to do here is make the other functions a 
 creates a global variable titled WMATA_AuthToken. Instead of a user defining a "sub_key" and then calling that in every function in the package, 
 they should be able to run this function, verify that the token is valid, and then not have to call it for each function.
 =#
-include("utils.jl")
+include("api.jl")
 
 function WMATA_auth(SubscriptionKey::String)
     url = "https://api.wmata.com/Misc/Validate"

--- a/src/authentication.jl
+++ b/src/authentication.jl
@@ -1,10 +1,3 @@
-#= 
-Function Name: WMATA_auth()
-Purpose: WMATA's API has an endpoint which allows us to verify whether a subscription key is valid, or if there is 
-an issue with their API. What I'd like to do here is make the other functions a bit less redundant by creating a function which 
-creates a global variable titled WMATA_AuthToken. Instead of a user defining a "sub_key" and then calling that in every function in the package, 
-they should be able to run this function, verify that the token is valid, and then not have to call it for each function.
-=#
 include("api.jl")
 
 function WMATA_auth(SubscriptionKey::String)

--- a/src/authentication.jl
+++ b/src/authentication.jl
@@ -5,14 +5,26 @@ an issue with their API. What I'd like to do here is make the other functions a 
 creates a global variable titled WMATA_AuthToken. Instead of a user defining a "sub_key" and then calling that in every function in the package, 
 they should be able to run this function, verify that the token is valid, and then not have to call it for each function.
 =#
+include("utils.jl")
+
 function WMATA_auth(SubscriptionKey::String)
     url = "https://api.wmata.com/Misc/Validate"
     subscription_key = Dict("api_key" => SubscriptionKey)
+
     try 
         r = request("GET", url, subscription_key)
     catch 
         @error "Invalid Subscription Key. Please refer to your WMATA account."
     end
-    global WMATA_AuthToken = SubscriptionKey
+
+    global wmata = wmata_API(
+        SubscriptionKey, 
+        "https://api.wmata.com/Rail.svc/json/jStations", 
+        "https://api.wmata.com/Rail.svc/json/jStationTimes", 
+        "https://api.wmata.com/StationPrediction.svc/json/GetPrediction/", 
+        "https://api.wmata.com/Rail.svc/json/jPath?", 
+        "https://api.wmata.com/Rail.svc/json/jSrcStationToDstStationInfo"
+    )
+
     println("Authentication complete.")
 end

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -9,9 +9,7 @@ function station_list(;LineCode::String = "All", IncludeAdditionalInfo::Bool = f
         url = "https://api.wmata.com/Rail.svc/json/jStations" * "?LineCode=" * LineCode
     end
 
-    subscription_key = Dict("api_key" => WMATA_AuthToken)
-    r = request("GET", url, subscription_key)
-    r = parse(String(r.body))
+    r = wmata_request(url)
 
     name = [station["Name"] for station in r["Stations"]]
     station_code = [station["Code"] for station in r["Stations"]]

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -4,9 +4,9 @@ function station_list(;LineCode::String = "All", IncludeAdditionalInfo::Bool = f
     LineCode = verify_line_input(LineCode)
 
     if LineCode == "All" 
-        url = "https://api.wmata.com/Rail.svc/json/jStations"
+        url = wmata.station_list_url
     else 
-        url = "https://api.wmata.com/Rail.svc/json/jStations" * "?LineCode=" * LineCode
+        url = wmata.station_list_url * "?LineCode=" * LineCode
     end
 
     r = wmata_request(url)
@@ -64,11 +64,9 @@ function station_timings(;StationCode::String = "", StationName::String = "")
         verify_station_input(StationCode)
     end 
 
-    url = "https://api.wmata.com/Rail.svc/json/jStationTimes" * "?StationCode=" * StationCode
+    url = wmata.station_timings_url * "?StationCode=" * StationCode
     
-    subscription_key = Dict("api_key" => WMATA_AuthToken)
-    r = request("GET", url, subscription_key)
-    r = parse(String(r.body))
+    r = wmata_request(url)
 
     days_of_week = ["Sunday" ,"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
 
@@ -121,10 +119,9 @@ function rail_predictions(;StationCode::String = "All", StationName::String = ""
         verify_station_input(StationCode)
     end 
 
-    url = "https://api.wmata.com/StationPrediction.svc/json/GetPrediction/" * StationCode * "/"
-    subscription_key = Dict("api_key" => WMATA_AuthToken)
-    r = request("GET", url, subscription_key)
-    r = parse(String(r.body))
+    url = wmata.rail_predictions_url * StationCode * "/"
+
+    r = wmata_request(url)
 
     lines = [station["Line"] for station in r["Trains"]]
     destination = [String(station["Destination"]) for station in r["Trains"]]
@@ -149,10 +146,9 @@ function path_between(;FromStationCode::String, ToStationCode::String)
     FromStationCode = verify_station_input(FromStationCode)
     ToStationCode = verify_station_input(ToStationCode)
 
-    url = "https://api.wmata.com/Rail.svc/json/jPath?" * "FromStationCode=" * FromStationCode * "&" * "ToStationCode=" * ToStationCode
-    subscription_key = Dict("api_key" => WMATA_AuthToken)
-    r = request("GET", url, subscription_key)
-    r = parse(String(r.body))
+    url = wmata.paths_url * "FromStationCode=" * FromStationCode * "&" * "ToStationCode=" * ToStationCode
+    
+    r = wmata_request(url)
 
     seq_nums = [r["Path"][path_point]["SeqNum"] for path_point in 1:length(r["Path"])]
     station_names = [r["Path"][path_point]["StationName"] for path_point in 1:length(r["Path"])]
@@ -179,14 +175,12 @@ function station_to_station(;FromStationCode::String = "", ToStationCode::String
     ToStationCode = verify_station_input(ToStationCode)
 
     if (FromStationCode == "" && ToStationCode == "")
-        url = "https://api.wmata.com/Rail.svc/json/jSrcStationToDstStationInfo"
+        url = wmata.station_to_station_url
     else
-        url = "https://api.wmata.com/Rail.svc/json/jSrcStationToDstStationInfo?" * "FromStationCode=" * FromStationCode * "&" * "ToStationCode=" * ToStationCode
+        url = wmata.station_to_station_url * "FromStationCode=" * FromStationCode * "&" * "ToStationCode=" * ToStationCode
     end
 
-    subscription_key = Dict("api_key" => WMATA_AuthToken)
-    r = request("GET", url, subscription_key)
-    r = parse(String(r.body))
+    r = wmata_request(url)
 
     origin_stations = [r["StationToStationInfos"][num]["SourceStation"] for num in 1:length(r["StationToStationInfos"])]
     destination_stations = [r["StationToStationInfos"][num]["DestinationStation"] for num in 1:length(r["StationToStationInfos"])]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,9 +3,17 @@ since we're dealing with user input, it makes sense to build in some checks to t
 so that mistakes are obvious and not mysterious.
 =#
 
-#=
-wrapper for API request.
-=#
+# struct containing api key and urls
+struct wmata_API 
+    api_key::String 
+    station_list_url::String
+    station_timings_url::String 
+    rail_predictions_url::String
+    paths_url::String 
+    station_to_station_url::String
+end
+
+# wrapper for API requests.
 function wmata_request(url::String)
     subscription_key = Dict("api_key" => WMATA_AuthToken)
     api_response = parse(String(request("GET", url, subscription_key).body))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,8 +1,3 @@
-#=
-since we're dealing with user input, it makes sense to build in some checks to the functions 
-so that mistakes are obvious and not mysterious.
-=#
-
 # wrapper for API requests.
 function wmata_request(url::String)
     subscription_key = Dict("api_key" => wmata.api_key)
@@ -38,7 +33,7 @@ end
 #=
 support optional argument in functions that involve pulling details
  based on a station code - enables a user to use a station name if they 
- don't know the code.
+ don't know the station code.
 =# 
 function get_station_code(StationName::String)
     r = wmata_request(wmata.station_list_url)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -43,7 +43,7 @@ support optional argument in functions that involve pulling details
  don't know the code.
 =# 
 function get_station_code(StationName::String)
-    subscription_key = Dict("api_key" => WMATA_AuthToken)
+    subscription_key = Dict("api_key" => wmata.api_key)
     r = request("GET", "https://api.wmata.com/Rail.svc/json/jStations", subscription_key)
     r = parse(String(r.body))
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,19 +3,9 @@ since we're dealing with user input, it makes sense to build in some checks to t
 so that mistakes are obvious and not mysterious.
 =#
 
-# struct containing api key and urls
-struct wmata_API 
-    api_key::String 
-    station_list_url::String
-    station_timings_url::String 
-    rail_predictions_url::String
-    paths_url::String 
-    station_to_station_url::String
-end
-
 # wrapper for API requests.
 function wmata_request(url::String)
-    subscription_key = Dict("api_key" => WMATA_AuthToken)
+    subscription_key = Dict("api_key" => wmata.api_key)
     api_response = parse(String(request("GET", url, subscription_key).body))
     
     return api_response
@@ -34,7 +24,7 @@ end
 # verify that a station code has a match in the WMATA endpoint.
 function verify_station_input(station_input)
     # this function relies on the same endpoint that the station_list function does.
-    subscription_key = Dict("api_key" => WMATA_AuthToken)
+    subscription_key = Dict("api_key" => wmata.api_key)
     r = request("GET", "https://api.wmata.com/Rail.svc/json/jStations", subscription_key)
     r = parse(String(r.body))
     

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -24,9 +24,7 @@ end
 # verify that a station code has a match in the WMATA endpoint.
 function verify_station_input(station_input)
     # this function relies on the same endpoint that the station_list function does.
-    subscription_key = Dict("api_key" => wmata.api_key)
-    r = request("GET", "https://api.wmata.com/Rail.svc/json/jStations", subscription_key)
-    r = parse(String(r.body))
+    r = wmata_request(wmata.station_list_url)
     
     valid_station_codes = push!([station["Code"] for station in r["Stations"]], "All")
 
@@ -43,9 +41,7 @@ support optional argument in functions that involve pulling details
  don't know the code.
 =# 
 function get_station_code(StationName::String)
-    subscription_key = Dict("api_key" => wmata.api_key)
-    r = request("GET", "https://api.wmata.com/Rail.svc/json/jStations", subscription_key)
-    r = parse(String(r.body))
+    r = wmata_request(wmata.station_list_url)
 
     stations = Dict(
         [station["Name"] for station in r["Stations"]] .=> [station["Code"] for station in r["Stations"]]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,6 +3,16 @@ since we're dealing with user input, it makes sense to build in some checks to t
 so that mistakes are obvious and not mysterious.
 =#
 
+#=
+wrapper for API request.
+=#
+function wmata_request(url::String)
+    subscription_key = Dict("api_key" => WMATA_AuthToken)
+    api_response = parse(String(request("GET", url, subscription_key).body))
+    
+    return api_response
+end
+
 # verify that a linecode is one that makes sense
 function verify_line_input(line_input)
     line_colors = ["RD", "BL", "YL", "OR", "GR", "SV", "All"]


### PR DESCRIPTION
This PR streamlines the requests code a bit by creating a `wmata_request` function wrapping repeated code from the various rail functions. In addition, `WMATA_Auth` has been revised to generate a global struct called `wmata` containing the API key and different URL endpoints for making requests.

This cleans up some of the rail code quite a bit as the URLs are not just hanging out inside of each function. Functions living in `rail.jl` or `utils.jl` (or anywhere else after running `WMATA_Auth`) have access to the elements of this struct.