### PR TITLE
Convert Arrival Times

### DIFF
--- a/src/rail.jl
+++ b/src/rail.jl
@@ -138,7 +138,7 @@ function rail_predictions(;StationCode::String = "All", StationName::String = ""
         "Cars" => cars, 
         "Destination" => destination, 
         "Group" => group, 
-        "Minutes" => mins
+        "Minutes" => convert_arrival_times(mins)
         )
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,7 +58,7 @@ function convert_arrival_times(arrival_times::Vector{String})
     for time in arrival_times 
         if time == "ARR"
             push!(converted_times, 0)
-        elseif time == "-"
+        elseif occursin(time, "-")
             push!(converted_times, missing) 
         else  
             push!(converted_times, Base.parse(Int64, time))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -48,3 +48,23 @@ function get_station_code(StationName::String)
         return stations[StationName]
     end
 end
+
+#=
+it makes sense that we'd want to parse arrival times to a better format (aka one that we can do arithmetic on), 
+  there is probably a more Juli-onic way to do this but this is my best attempt at the moment. 
+=#
+function convert_arrival_times(arrival_times::Vector{Any})
+    converted_times = []
+    for time in arrival_times 
+        if typeof(time) == String 
+            if time == "ARR"
+                push!(converted_times, 0)
+            else 
+                push!(converted_times, missing) 
+            end 
+        elseif typeof(time) == Int64 
+            push!(converted_times, time) 
+        end 
+    end
+    return convert(Vector{Union{Missing, Int64}}, converted_times)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -53,17 +53,15 @@ end
 it makes sense that we'd want to parse arrival times to a better format (aka one that we can do arithmetic on), 
   there is probably a more Juli-onic way to do this but this is my best attempt at the moment. 
 =#
-function convert_arrival_times(arrival_times::Vector{Any})
+function convert_arrival_times(arrival_times::Vector{String})
     converted_times = []
     for time in arrival_times 
-        if typeof(time) == String 
-            if time == "ARR"
-                push!(converted_times, 0)
-            else 
-                push!(converted_times, missing) 
-            end 
-        elseif typeof(time) == Int64 
-            push!(converted_times, time) 
+        if time == "ARR"
+            push!(converted_times, 0)
+        elseif time == "-"
+            push!(converted_times, missing) 
+        else  
+            push!(converted_times, Base.parse(Int64, time))
         end 
     end
     return convert(Vector{Union{Missing, Int64}}, converted_times)


### PR DESCRIPTION
Arrival times should not just be a string straight across, since it's probable that we'll want to do some types of arithmetic on the "minutes" column. This adds a function to convert those to a vector allowing missing values and integers. 
- if the minutes to arrival is "ARR", it is 0.
- if minutes to arrival is "---" or something similar , it is missing. 
- otherwise, it is whatever the minutes to arrival is.