### PR TITLE
Train positions and function cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ WMATA_auth("your subscription key")
 Based on the *Real Time Rail Predictions* methods described in WMATA's documentation [here](https://developer.wmata.com/docs/services/547636a6f9182302184cda78/operations/547636a6f918230da855363f). You can provide a station code or station name.
 
 ```
-rail_predictions(StationCode = "All")
+get_rail_predictions(StationCode = "All")
 ```
 Returns a DataFrame of next train arrival information for one or more stations. Will return an empty set of results when no predictions are available. Use All for the StationCodes parameter to return predictions for all stations.
 
@@ -45,7 +45,7 @@ Next train arrival information is refreshed once every 20 to 30 seconds approxim
 * **Group:** denotes the track this train is on, but does not necessarily equate to Track 1 or Track 2. With the exception of terminal stations, predictions at the same station with different Group values refer to trains on different tracks.
 * **Minutes:** minutes until arrival. Can be a numeric value, ARR (arriving), BRD (boarding), ---, or empty.
 
-## station_list()
+## get_station_list()
 Returns a DataFrame of station location and address information based on a given LineCode. Use `LineCode = "All"` to return all stations. 
 
 *LineCode* - can be "All" or one of the following two-letter abbreviations: 
@@ -84,7 +84,7 @@ This will return the same DataFrame as above, with the following additions:
 * **LineCode4:*** Additional line served by this station, if applicable. Currently not in use.
 * **StationTogether1:** For stations with multiple platforms (e.g.: Gallery Place, Fort Totten, L'Enfant Plaza, and Metro Center), the additional StationCode will be listed here.
 
-## station_timings()
+## get_station_timings()
 
 Returns a DataFrame of opening and scheduled first/last train times based on a given StationCode or StationName.
 
@@ -121,7 +121,7 @@ The resulting DataFrame includes:
 * **LineCode:**	Two-letter abbreviation for the line (e.g.: RD, BL, YL, OR, GR, or SV) this station's platform is on.
 * **DistanceToPrev:** Distance in feet to the previous station in the list.
 
-## station_to_station()
+## get_station_to_station()
 
 Returns a DataFrame with the distance, fare information, and estimated travel time between any two stations, including those on different lines. 
 
@@ -139,3 +139,24 @@ The resulting DataFrame includes:
 * **SeniorRailFare:** reduced fare for senior citizens or people with disabilities.
 * **PeakRailFare:** fare during peak times (weekdays from opening to 9:30 AM and 3-7 PM, and weekends from midnight to closing).
 * **OffPeakRailFare:** fare during off-peak times (times other than the ones described below).
+
+## get_train_positions()
+
+Returns uniquely identifiable trains in service and what track circuits they currently occupy. Will return an empty set of results when no positions are available.
+
+Data is refreshed once every 7-10 seconds.
+
+**CarCount:** number of cars. Can sometimes be 0 when there is no data available.
+**CircuitId:**	the circuit identifier the train is currently on. This identifier can be referenced from the Standard Routes method.
+**DestinationStationCode:**	destination station code. Can be NULL. Use this value in other rail-related APIs to retrieve data about a station. Note **that this value may sometimes differ from the destination station code returned by our Next Trains methods.
+**DirectionNum:** the direction of movement regardless of which track the train is on. Valid values are 1 or 2. Generally speaking, trains with direction 1 are northbound/eastbound, while trains with direction 2 are southbound/westbound.
+**LineCode:** two-letter abbreviation for the line (e.g.: RD, BL, YL, OR, GR, or SV). May also be NULL in certain cases.
+**SecondsAtLocation:** approximate "dwell time". This is not an exact value, but can be used to determine how long a train has been reported at the same track circuit.
+**ServiceType:** Service Type of a train, can be any of the following Service Types
+**TrainId:** uniquely identifiable internal train identifier.
+**TrainNumber:** non-unique train identifier, often used by WMATA's Rail Scheduling and Operations Teams, as well as over open radio communication.
+**Service Types:**
+- *NoPassengers:* This is a non-revenue train with no passengers on board. Note that this designation of NoPassengers does not necessarily correlate with PIDS "No Passengers". As of 08/22/2016, this functionality has been reinstated to include all non-revenue vehicles, with minor exceptions.
+- *Normal:*	this is a normal revenue service train.
+- *Special:* this is a special revenue service train with an unspecified line and destination. This is more prevalent during scheduled track work.
+- *Unknown:* this often denotes cases with unknown data or work vehicles.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The resulting DataFrame includes:
 
 * **StationName:** name of the station.
 * **StationCode:** three digit station code. Can be used as an input to `rail_predictions()`.
+* **LineCode:** the LineCode of the station.
 * **Latitude:** Latitude.
 * **Longitude:** Longitude.
 * **City:** the city in which the station is located. 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # WMATA.jl
-Julia package which simplifies the process of interacting with WMATA's public API.
+Julia package which simplifies the process of interacting with WMATA's public API via an opinionated wrapper to Julia's `DataFrames` package.
 
 # Getting Started 
 ## Installation 
-Install the package via Julia's package system like so: 
+Install the package from GitHub via Julia's package system: 
 
 ```julia 
 pkg> add "https://github.com/mistermichaelll/WMATA.jl"

--- a/src/WMATA.jl
+++ b/src/WMATA.jl
@@ -3,6 +3,6 @@ include("authentication.jl")
 include("rail.jl")
 
 import DataFrames.DataFrame, JSON.parse, HTTP.request
-export rail_predictions, station_list, station_timings, WMATA_auth, path_between, station_to_station
+export rail_predictions, station_list, station_timings, WMATA_auth, path_between, station_to_station, get_train_positions
 
 end

--- a/src/WMATA.jl
+++ b/src/WMATA.jl
@@ -2,7 +2,7 @@ module WMATA
 include("authentication.jl")
 include("rail.jl")
 
-import DataFrames.DataFrame, JSON.parse, HTTP.request, DataFrames.rename!
-export rail_predictions, station_list, station_timings, WMATA_auth, path_between, station_to_station, get_train_positions
+import DataFrames.DataFrame, JSON.parse, HTTP.request, DataFrames.rename!, DataFrames.names
+export rail_predictions, station_list, station_timings, WMATA_auth, path_between, station_to_station, get_train_positions, test_station_list
 
 end

--- a/src/WMATA.jl
+++ b/src/WMATA.jl
@@ -2,7 +2,7 @@ module WMATA
 include("authentication.jl")
 include("rail.jl")
 
-import DataFrames.DataFrame, JSON.parse, HTTP.request
+import DataFrames.DataFrame, JSON.parse, HTTP.request, DataFrames.rename!
 export rail_predictions, station_list, station_timings, WMATA_auth, path_between, station_to_station, get_train_positions
 
 end

--- a/src/WMATA.jl
+++ b/src/WMATA.jl
@@ -2,7 +2,7 @@ module WMATA
 include("authentication.jl")
 include("rail.jl")
 
-import DataFrames.DataFrame, JSON.parse, HTTP.request, DataFrames.rename!, DataFrames.names
+import DataFrames.DataFrame, JSON.parse, HTTP.request, DataFrames.rename!, DataFrames.names, DataFrames.nrow
 export get_rail_predictions, get_station_list, get_station_timings, WMATA_auth, get_path_between, get_station_to_station, get_train_positions
 
 end

--- a/src/WMATA.jl
+++ b/src/WMATA.jl
@@ -3,6 +3,6 @@ include("authentication.jl")
 include("rail.jl")
 
 import DataFrames.DataFrame, JSON.parse, HTTP.request, DataFrames.rename!, DataFrames.names
-export rail_predictions, station_list, station_timings, WMATA_auth, path_between, station_to_station, get_train_positions, test_station_list
+export get_rail_predictions, get_station_list, get_station_timings, WMATA_auth, get_path_between, get_station_to_station, get_train_positions
 
 end

--- a/src/api.jl
+++ b/src/api.jl
@@ -6,4 +6,5 @@ struct wmata_API
     rail_predictions_url::String
     paths_url::String 
     station_to_station_url::String
+    train_positions_url::String
 end

--- a/src/authentication.jl
+++ b/src/authentication.jl
@@ -16,7 +16,8 @@ function WMATA_auth(SubscriptionKey::String)
         "https://api.wmata.com/Rail.svc/json/jStationTimes", 
         "https://api.wmata.com/StationPrediction.svc/json/GetPrediction/", 
         "https://api.wmata.com/Rail.svc/json/jPath?", 
-        "https://api.wmata.com/Rail.svc/json/jSrcStationToDstStationInfo"
+        "https://api.wmata.com/Rail.svc/json/jSrcStationToDstStationInfo", 
+        "https://api.wmata.com/TrainPositions/TrainPositions?contentType=json"
     )
 
     println("Authentication complete.")

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -123,23 +123,23 @@ function rail_predictions(;StationCode::String = "All", StationName::String = ""
 
     r = wmata_request(url)
 
-    lines = [station["Line"] for station in r["Trains"]]
-    destination = [String(station["Destination"]) for station in r["Trains"]]
-    group = [station["Group"] for station in r["Trains"]]
-    location = [String(station["LocationName"]) for station in r["Trains"]]
-    location_code = [String(station["LocationCode"]) for station in r["Trains"]]
-    mins = [station["Min"] for station in r["Trains"]]
-    cars = [station["Car"] for station in r["Trains"]]
+    response_elements = [
+        "LocationName", 
+        "LocationCode",
+        "Line", 
+        "Car",
+        "Destination", 
+        "Group",  
+        "Min" 
+    ]
 
-    return DataFrame(
-        "Arrival Station" => location, 
-        "Location Code" => location_code, 
-        "Line" => lines, 
-        "Cars" => cars, 
-        "Destination" => destination, 
-        "Group" => group, 
-        "Minutes" => convert_arrival_times(mins)
-        )
+    rail_predictions_constructor(id_col::String) = (id_col => [station[id_col] for station in r["Trains"]])
+
+    rail_predictions = DataFrame(map(rail_predictions_constructor, response_elements))
+    rename!(rail_predictions, :LocationName => :ArrivalStation)
+    rail_predictions[!, :Min] = convert_arrival_times(rail_predictions[!, :Min])
+
+    return rail_predictions
 end
 
 function path_between(;FromStationCode::String, ToStationCode::String)

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -217,10 +217,9 @@ function get_train_positions()
     "CircuitId"
     ]
 
-    # a short function to help us save some code
-    get_position_elements(id_col::String) = (id_col => [train[id_col] for train in train_positions])
+    train_position_constructor(id_col::String) = (id_col => [train[id_col] for train in train_positions])
 
-    train_position_mapped = map(get_position_elements, response_elements)
-
-    return DataFrame(train_position_mapped)
+    return DataFrame(
+        map(train_position_constructor, response_elements)
+        )
 end

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -141,11 +141,11 @@ function rail_predictions(;StationCode::String = "All", StationName::String = ""
         "Min" 
     ]
 
-    rail_predictions_constructor(id_col::String) = (id_col => [station[id_col] for station in r["Trains"]])
-
     rail_predictions = DataFrame(
-        map(rail_predictions_constructor, response_elements)
+        map(id_col -> (id_col => [station[id_col] for station in r["Trains"]]), 
+        response_elements
         )
+    )
         
     rename!(rail_predictions, :LocationName => :ArrivalStation)
     rail_predictions[!, :Min] = convert_arrival_times(rail_predictions[!, :Min])
@@ -228,9 +228,9 @@ function get_train_positions()
     "CircuitId"
     ]
 
-    train_position_constructor(id_col::String) = (id_col => [train[id_col] for train in train_positions])
-
     return DataFrame(
-        map(train_position_constructor, response_elements)
+        map(id_col -> (id_col => [train[id_col] for train in train_positions]),
+        response_elements
         )
+    )
 end

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -34,7 +34,9 @@ function station_list(;LineCode::String = "All", IncludeAdditionalInfo::Bool = f
     else 
         response_elements 
     end
-
+    
+    # function we can map to the response elements to efficiently construct 
+    #  our dataframe!
     function station_list_constructor(id_col::String)
         address_element = ["City", "State", "Street", "Zip"]
 

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -135,7 +135,10 @@ function rail_predictions(;StationCode::String = "All", StationName::String = ""
 
     rail_predictions_constructor(id_col::String) = (id_col => [station[id_col] for station in r["Trains"]])
 
-    rail_predictions = DataFrame(map(rail_predictions_constructor, response_elements))
+    rail_predictions = DataFrame(
+        map(rail_predictions_constructor, response_elements)
+        )
+        
     rename!(rail_predictions, :LocationName => :ArrivalStation)
     rail_predictions[!, :Min] = convert_arrival_times(rail_predictions[!, :Min])
 

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -49,7 +49,7 @@ function station_list(;LineCode::String = "All", IncludeAdditionalInfo::Bool = f
 
     station_list = DataFrame(
         map(station_list_constructor, response_elements)
-        )
+    )
 
     # rename some columns to be clearer
     new_names = Dict(

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -200,3 +200,27 @@ function station_to_station(;FromStationCode::String = "", ToStationCode::String
         "OffPeakRailFare" => off_peak_rail_fare
         )
 end
+
+function get_train_positions() 
+    r = wmata_request(wmata.train_positions_url)
+    train_positions = r["TrainPositions"]
+
+    response_elements = [
+    "CarCount", 
+    "DestinationStationCode",
+    "DirectionNum", 
+    "LineCode",	
+    "SecondsAtLocation",	
+    "ServiceType",	
+    "TrainId",
+    "TrainNumber",
+    "CircuitId"
+    ]
+
+    # a short function to help us save some code
+    get_position_elements(id_col::String) = (id_col => [train[id_col] for train in train_positions])
+
+    train_position_mapped = map(get_position_elements, response_elements)
+
+    return DataFrame(train_position_mapped)
+end

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -48,7 +48,9 @@ function get_station_list(;LineCode::String = "All", IncludeAdditionalInfo::Bool
     end
 
     station_list = DataFrame(
-        map(station_list_constructor, response_elements)
+        map(station_list_constructor, 
+        response_elements
+        )
     )
 
     # rename some columns to be clearer

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -29,8 +29,7 @@ function station_list(;LineCode::String = "All", IncludeAdditionalInfo::Bool = f
             ["LineCode2", 
             "LineCode3", 
             "LineCode4", 
-            "StationTogether1"
-            ]
+            "StationTogether1"]
         )
     else 
         response_elements 

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -234,16 +234,3 @@ function get_train_positions()
         map(train_position_constructor, response_elements)
         )
 end
-
-
-function test_station_list(;LineCode::String = "All", IncludeAdditionalInfo::Bool = false)
-    LineCode = verify_line_input(LineCode)
-
-    if LineCode == "All" 
-        url = wmata.station_list_url
-    else 
-        url = wmata.station_list_url * "?LineCode=" * LineCode
-    end
-
-    r = wmata_request(url)
-end

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -26,10 +26,11 @@ function station_list(;LineCode::String = "All", IncludeAdditionalInfo::Bool = f
     if IncludeAdditionalInfo == true 
         append!(
             response_elements,
-            ["StationTogether1",
-            "LineCode2", 
+            ["LineCode2", 
             "LineCode3", 
-            "LineCode4"]
+            "LineCode4", 
+            "StationTogether1"
+            ]
         )
     else 
         response_elements 

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -119,7 +119,7 @@ function station_timings(;StationCode::String = "", StationName::String = "")
         "FirstTrainTime" => first_trains_times, 
         "LastTrainDestination" => last_trains_destinations, 
         "LastTrainTime" => last_trains_times
-        )
+    )
 end
 
 function rail_predictions(;StationCode::String = "All", StationName::String = "")
@@ -179,7 +179,7 @@ function path_between(;FromStationCode::String, ToStationCode::String)
             "StationCode" => station_codes, 
             "LineCode" => line_codes,
             "DistanceToPrevious" => distances_to_prev
-            )
+        )
     end
 end
 

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -1,6 +1,6 @@
 include("utils.jl")
 
-function station_list(;LineCode::String = "All", IncludeAdditionalInfo::Bool = false)
+function get_station_list(;LineCode::String = "All", IncludeAdditionalInfo::Bool = false)
     LineCode = verify_line_input(LineCode)
 
     if LineCode == "All" 
@@ -67,7 +67,7 @@ function station_list(;LineCode::String = "All", IncludeAdditionalInfo::Bool = f
     return station_list
 end
 
-function station_timings(;StationCode::String = "", StationName::String = "")
+function get_station_timings(;StationCode::String = "", StationName::String = "")
     if StationName != ""
         StationCode = get_station_code(StationName)
     else 
@@ -122,7 +122,7 @@ function station_timings(;StationCode::String = "", StationName::String = "")
     )
 end
 
-function rail_predictions(;StationCode::String = "All", StationName::String = "")
+function get_rail_predictions(;StationCode::String = "All", StationName::String = "")
     if StationName != ""
         StationCode = get_station_code(StationName)
     else 
@@ -155,7 +155,7 @@ function rail_predictions(;StationCode::String = "All", StationName::String = ""
     return rail_predictions
 end
 
-function path_between(;FromStationCode::String, ToStationCode::String)
+function get_path_between(;FromStationCode::String, ToStationCode::String)
     FromStationCode = verify_station_input(FromStationCode)
     ToStationCode = verify_station_input(ToStationCode)
 
@@ -183,7 +183,7 @@ function path_between(;FromStationCode::String, ToStationCode::String)
     end
 end
 
-function station_to_station(;FromStationCode::String = "", ToStationCode::String = "")
+function get_station_to_station(;FromStationCode::String = "", ToStationCode::String = "")
     FromStationCode = verify_station_input(FromStationCode)
     ToStationCode = verify_station_input(ToStationCode)
 

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -163,23 +163,25 @@ function get_path_between(;FromStationCode::String, ToStationCode::String)
     
     r = wmata_request(url)
 
-    seq_nums = [r["Path"][path_point]["SeqNum"] for path_point in 1:length(r["Path"])]
-    station_names = [r["Path"][path_point]["StationName"] for path_point in 1:length(r["Path"])]
-    station_codes = [r["Path"][path_point]["StationCode"] for path_point in 1:length(r["Path"])]
-    line_codes = [r["Path"][path_point]["LineCode"] for path_point in 1:length(r["Path"])]
-    distances_to_prev = [r["Path"][path_point]["DistanceToPrev"] for path_point in 1:length(r["Path"])]
+    response_elements = [
+        "SeqNum", 
+        "StationName", 
+        "StationCode", 
+        "LineCode", 
+        "DistanceToPrev"
+    ]
 
-    # check if user has input stations which are on the same line.
-    if length(seq_nums) == 0 & length(station_names) == 0
+    paths_between = DataFrame(
+        map(
+        id_col -> (id_col => [r["Path"][path_point][id_col] for path_point in 1:length(r["Path"])]), 
+        response_elements
+        )
+    )
+
+    if nrow(paths_between) == 0 
         @error "No path between stations. Did you choose stations on the same line?"
     else 
-        return DataFrame(
-            "SequenceNumber" => seq_nums, 
-            "StationName" => station_names, 
-            "StationCode" => station_codes, 
-            "LineCode" => line_codes,
-            "DistanceToPrevious" => distances_to_prev
-        )
+        return paths_between 
     end
 end
 


### PR DESCRIPTION
This PR adds the `get_train_positions()` function as well as "get" to the beginning of the function names. I feel this is a bit more descriptive to their behavior. 

In addition, this PR rewrites the majority of the functions to construct dataframes via `map` instead of explicitly. This feels a bit cleaner to me since previously they were all using a brute-force method of list comprehensions. 

`get_station_timings()` still kind of uses brute force... but detangling that response is a bit messy so I'm leaving it as-is for now.