### PR TITLE
Add Rail Incident Function + Eliminate Nested Functions

### DIFF
--- a/src/WMATA.jl
+++ b/src/WMATA.jl
@@ -3,7 +3,8 @@ include("authentication.jl")
 include("rail.jl")
 
 import DataFrames.DataFrame, JSON.parse, HTTP.request, DataFrames.rename!, DataFrames.names, DataFrames.nrow
-export get_rail_predictions, get_station_list, get_station_timings, WMATA_auth, get_path_between, get_station_to_station, get_train_positions
-export get_rail_incidents
+export WMATA_auth
+export get_rail_predictions, get_station_list, get_station_timings, get_path_between, get_station_to_station
+export get_rail_incidents, get_train_positions
 
 end

--- a/src/WMATA.jl
+++ b/src/WMATA.jl
@@ -4,5 +4,6 @@ include("rail.jl")
 
 import DataFrames.DataFrame, JSON.parse, HTTP.request, DataFrames.rename!, DataFrames.names, DataFrames.nrow
 export get_rail_predictions, get_station_list, get_station_timings, WMATA_auth, get_path_between, get_station_to_station, get_train_positions
+export get_rail_incidents
 
 end

--- a/src/api.jl
+++ b/src/api.jl
@@ -7,4 +7,5 @@ struct wmata_API
     paths_url::String 
     station_to_station_url::String
     train_positions_url::String
+    rail_incidents_url::String
 end

--- a/src/authentication.jl
+++ b/src/authentication.jl
@@ -17,7 +17,8 @@ function WMATA_auth(SubscriptionKey::String)
         "https://api.wmata.com/StationPrediction.svc/json/GetPrediction/", 
         "https://api.wmata.com/Rail.svc/json/jPath?", 
         "https://api.wmata.com/Rail.svc/json/jSrcStationToDstStationInfo", 
-        "https://api.wmata.com/TrainPositions/TrainPositions?contentType=json"
+        "https://api.wmata.com/TrainPositions/TrainPositions?contentType=json", 
+        "https://api.wmata.com/Incidents.svc/json/Incidents"
     )
 
     println("Authentication complete.")

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -34,24 +34,15 @@ function get_station_list(;LineCode::String = "All", IncludeAdditionalInfo::Bool
     else 
         response_elements 
     end
-    
-    # function we can map to the response elements to efficiently construct 
-    #  our dataframe!
-    function _station_list_constructor(id_col::String)
-        address_element = ["City", "State", "Street", "Zip"]
-
-        if id_col in address_element 
-            (id_col => [station["Address"][id_col] for station in r["Stations"]])
-        else 
-            (id_col => [station[id_col] for station in r["Stations"]])
-        end 
-    end
 
     station_list = DataFrame(
-        map(
-        _station_list_constructor, 
-        response_elements
-        )
+        map(response_elements) do id_col 
+            if id_col in ["City", "State", "Street", "Zip"] 
+                (id_col => [station["Address"][id_col] for station in r["Stations"]])
+            else 
+                (id_col => [station[id_col] for station in r["Stations"]])
+            end 
+        end
     )
 
     # rename some columns to be clearer
@@ -208,21 +199,14 @@ function get_station_to_station(;FromStationCode::String = "", ToStationCode::St
         "OffPeakTime"
     ]
 
-    function _station_to_station_constructor(id_col::String) 
-        rail_fare_elements = ["SeniorDisabled", "PeakTime", "OffPeakTime"]
-
-        if id_col in rail_fare_elements 
+    return DataFrame(
+       map(response_elements) do id_col 
+        if id_col in ["SeniorDisabled", "PeakTime", "OffPeakTime"]
             (id_col => [r["StationToStationInfos"][num]["RailFare"][id_col] for num in 1:length(r["StationToStationInfos"])])
         else 
             (id_col => [r["StationToStationInfos"][num][id_col] for num in 1:length(r["StationToStationInfos"])])
         end
-    end
-
-    return DataFrame(
-       map(
-           _station_to_station_constructor, 
-           response_elements
-       ) 
+        end
     )
 end
 
@@ -271,6 +255,6 @@ function get_rail_incidents()
         else 
             (id_col => [r["Incidents"][incident][id_col] for incident in 1:length(r["Incidents"])]) 
         end
-    end
+        end
     )
 end

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -147,7 +147,8 @@ function get_rail_predictions(;StationCode::String = "All", StationName::String 
     ]
 
     rail_predictions = DataFrame(
-        map(id_col -> (id_col => [station[id_col] for station in r["Trains"]]), 
+        map(
+        id_col -> (id_col => [station[id_col] for station in r["Trains"]]), 
         response_elements
         )
     )
@@ -242,7 +243,8 @@ function get_train_positions()
     ]
 
     return DataFrame(
-        map(id_col -> (id_col => [train[id_col] for train in train_positions]),
+        map(
+        id_col -> (id_col => [train[id_col] for train in train_positions]),
         response_elements
         )
     )
@@ -271,7 +273,8 @@ function get_rail_incidents()
     end
 
     DataFrame(
-        map(_rail_incidents_constructor, 
+        map(
+        _rail_incidents_constructor, 
         response_elements
         )
     )

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -263,7 +263,8 @@ function get_rail_incidents()
     "DateUpdated"
     ]
 
-    function _rail_incidents_constructor(id_col::String)
+    DataFrame(
+        map(response_elements) do id_col 
         if id_col == "LinesAffected"
             lines_affected = [r["Incidents"][incident][id_col] for incident in 1:length(r["Incidents"])]
             ("LinesAffected" => map(x -> split(replace(x, " " => ""), ';', keepempty = false), lines_affected))
@@ -271,11 +272,5 @@ function get_rail_incidents()
             (id_col => [r["Incidents"][incident][id_col] for incident in 1:length(r["Incidents"])]) 
         end
     end
-
-    DataFrame(
-        map(
-        _rail_incidents_constructor, 
-        response_elements
-        )
     )
 end

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -270,7 +270,7 @@ function get_rail_incidents()
         end
     end
 
-    DataFrame( 
+    DataFrame(
         map(_rail_incidents_constructor, 
         response_elements
         )

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -247,3 +247,23 @@ function get_train_positions()
         )
     )
 end
+
+function get_rail_incidents() 
+    r = wmata_request(wmata.rail_incidents_url)
+    
+    response_elements = [
+    "IncidentID", 
+    "Description", 
+    "EndLocationFullName", 
+    "PassengerDelay", 
+    "LinesAffected", 
+    "IncidentType", 
+    "DateUpdated"
+    ]
+
+    DataFrame( 
+        map(id_col -> (id_col => [r["Incidents"][incident][id_col] for incident in 1:length(r["Incidents"])]), 
+        response_elements
+        )
+    )
+end

--- a/src/rail.jl
+++ b/src/rail.jl
@@ -261,8 +261,17 @@ function get_rail_incidents()
     "DateUpdated"
     ]
 
+    function _rail_incidents_constructor(id_col::String)
+        if id_col == "LinesAffected"
+            lines_affected = [r["Incidents"][incident][id_col] for incident in 1:length(r["Incidents"])]
+            ("LinesAffected" => map(x -> split(replace(x, " " => ""), ';', keepempty = false), lines_affected))
+        else 
+            (id_col => [r["Incidents"][incident][id_col] for incident in 1:length(r["Incidents"])]) 
+        end
+    end
+
     DataFrame( 
-        map(id_col -> (id_col => [r["Incidents"][incident][id_col] for incident in 1:length(r["Incidents"])]), 
+        map(_rail_incidents_constructor, 
         response_elements
         )
     )


### PR DESCRIPTION
This PR adds `get_rail_incidents()` which returns a DataFrame of rail incidents and their corresponding lines. 

`LinesAffected` does not inherently come from the API as an array, but I've parsed it out to a vector. This means we can filter like this:

```julia 
incidents = get_rail_incidents()
filter(:LinesAffected => lines -> "BL" in lines, incidents)
#> 2×7 DataFrame
 Row │ IncidentID                         Description                        EndLocationFullName  PassengerDelay  LinesAffected              ⋯
     │ String                             String                             Nothing              Float64         Array…                     ⋯
─────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1 │ F399FCDE-142C-48D1-ACDA-B12F553A…  Thru Sunday's closing, there is …                                  0.0  SubString{String}["BL", "O ⋯
   2 │ 88D09EDF-A444-4894-BEFD-0F9D31CB…  Trains operate every 24 mins in …                                  0.0  SubString{String}["BL"]
```

AND - in addition, thanks to dzon in the Julia discord - I realized we can eliminate the nested `_constructor` functions with `do-end` syntax. This makes the mapping which builds the dataframes much cleaner and consolidates logic to a single spot.